### PR TITLE
Hide cloaked windows from source dropdown

### DIFF
--- a/PrismTextureStreamerFB/PrismTextureStreamerFB.vcxproj
+++ b/PrismTextureStreamerFB/PrismTextureStreamerFB.vcxproj
@@ -115,7 +115,7 @@
       <AdditionalLibraryDirectories>$(SolutionDir)Lib</AdditionalLibraryDirectories>
     </Link>
     <PostBuildEvent>
-      <Command>copy "H:\repos\PrismTextureStreamer\x64\Debug\PrismTextureStreamerFB.dll" "H:\SteamLibrary\steamapps\common\Euro Truck Simulator 2\bin\win_x64\plugins"</Command>
+      <Command>copy "$(OutputPath)PrismTextureStreamerFB.dll" "H:\SteamLibrary\steamapps\common\Euro Truck Simulator 2\bin\win_x64\plugins"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">

--- a/PrismTextureStreamerFB/menu/menu.cpp
+++ b/PrismTextureStreamerFB/menu/menu.cpp
@@ -20,8 +20,18 @@ using namespace scs_logging;
 #include "../sources/window.h"
 #include "../sources/wgc_window.h"
 
+#include <dwmapi.h>
+#pragma comment(lib, "dwmapi.lib")
 
 static bool menu_visible{};
+
+static bool IsWindowCloaked(HWND hwnd)
+{
+	BOOL cloaked = FALSE;
+	HRESULT hr = DwmGetWindowAttribute(hwnd, DWMWA_CLOAKED, &cloaked, sizeof(cloaked));
+	return SUCCEEDED(hr) && cloaked != FALSE;
+}
+
 void on_frame()
 {
 	static bool wasPressed = false;
@@ -138,6 +148,9 @@ void on_frame()
 			LONG exStyle = GetWindowLongA(hwnd, GWL_EXSTYLE);
 			if (exStyle & WS_EX_TOOLWINDOW)
 				return TRUE;
+
+			if (IsWindowCloaked(hwnd))
+				return TRUE; // skip any windows that are not currently being rendered by the system
 
 			std::string windowTitle;
 			bool hasTitle{};

--- a/PrismTextureStreamerFB/version.h
+++ b/PrismTextureStreamerFB/version.h
@@ -1,3 +1,3 @@
 #pragma once
 
-inline const char* g_version = "1.1.0";
+inline const char* g_version = "1.1.1";


### PR DESCRIPTION
## Summary

1. Filter out cloaked windows when enumerating windows for the selection dropdown using [DWMWA_CLOAKED](https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute) to exclude windows that are not currently rendered by the users PC (for example, background processes like TextInputHost.exe, ApplicationFrameHost.exe etc.). 

## Why

1. The dropdown could include hidden "cloaked" windows that can't actually be captured, which would show invalid selections, if they were selected the user would get a source failed error. Filtering them out makes the list match what users see in Alt+Tab (Only rendered windows by DWM)

Before:
<img width="589" height="348" alt="image" src="https://github.com/user-attachments/assets/e06b6679-8546-405b-a67a-7abf0233f25f" />

After:
<img width="596" height="331" alt="image" src="https://github.com/user-attachments/assets/c739b40c-0255-4c4f-8d86-2bd17755b5a7" />


 