### PR TITLE
Switch app names detection to HWD and moved menu visibilty to it's own function

### DIFF
--- a/PrismTextureStreamerFB/menu/menu.cpp
+++ b/PrismTextureStreamerFB/menu/menu.cpp
@@ -23,13 +23,29 @@ using namespace scs_logging;
 #include <dwmapi.h>
 #pragma comment(lib, "dwmapi.lib")
 
-static bool menu_visible{};
-
-static bool IsWindowCloaked(HWND hwnd)
+static bool IsWindowCloaked(HWND application_hwnd)
 {
 	BOOL cloaked = FALSE;
-	HRESULT hr = DwmGetWindowAttribute(hwnd, DWMWA_CLOAKED, &cloaked, sizeof(cloaked));
+	HRESULT hr = DwmGetWindowAttribute(application_hwnd, DWMWA_CLOAKED, &cloaked, sizeof(cloaked));
 	return SUCCEEDED(hr) && cloaked != FALSE;
+}
+
+struct window_entry_t
+{
+	std::string applicationName;
+	HWND application_hwnd{};
+};
+
+static bool menu_visible{};
+static void set_menu_visible(bool visible)
+{
+	menu_visible = visible;
+	dinput8::set_mouse(menu_visible);
+
+	if (ImGui::GetCurrentContext()) {
+		ImGuiIO* io = &ImGui::GetIO();
+		if (io) io->MouseDrawCursor = menu_visible;
+	}
 }
 
 void on_frame()
@@ -41,16 +57,9 @@ void on_frame()
 	bool isPressed = ctrlDown && f8Down;
 
 	if (isPressed && !wasPressed) {
-		menu_visible = !menu_visible;
-		dinput8::set_mouse(menu_visible);
-
-		if (ImGui::GetCurrentContext()) {
-			ImGuiIO* io = &ImGui::GetIO();
-			if (io) io->MouseDrawCursor = menu_visible;
-		}
+		set_menu_visible(!menu_visible);
 	}
 	wasPressed = isPressed;
-
 
 	if (menu_visible) {
 		ImGui::SetNextWindowSizeConstraints(ImVec2(584, 208), ImVec2(FLT_MAX, FLT_MAX));
@@ -130,38 +139,37 @@ void on_frame()
 
 			justSaved = true;
 			unsavedChanges = false;
+
+			set_menu_visible(false);
 		}
 		ImGui::EndDisabled();
 
 		if (unsavedChanges || justSaved) ImGui::PopStyleColor(3);
 
+		std::map<std::string, window_entry_t> applications; // window title, application name, application hwnd}
+		EnumWindows([](HWND application_hwnd, LPARAM lParam) -> BOOL {
+			auto* applications = reinterpret_cast<std::map<std::string, window_entry_t>*>(lParam);
 
-
-
-		std::map<std::string, std::string> applications; // window title, application name
-		EnumWindows([](HWND hwnd, LPARAM lParam) -> BOOL {
-			auto* applications = reinterpret_cast<std::map<std::string, std::string>*>(lParam);
-
-			if (!IsWindowVisible(hwnd))
+			if (!IsWindowVisible(application_hwnd))
 				return TRUE;
 
-			LONG exStyle = GetWindowLongA(hwnd, GWL_EXSTYLE);
+			LONG exStyle = GetWindowLongA(application_hwnd, GWL_EXSTYLE);
 			if (exStyle & WS_EX_TOOLWINDOW)
 				return TRUE;
 
-			if (IsWindowCloaked(hwnd))
+			if (IsWindowCloaked(application_hwnd))
 				return TRUE; // skip any windows that are not currently being rendered by the system
 
 			std::string windowTitle;
 			bool hasTitle{};
 
-			int titleLen = GetWindowTextLengthA(hwnd);
+			int titleLen = GetWindowTextLengthA(application_hwnd);
 			if (titleLen != 0)
 			{
 				hasTitle = true;
 
 				windowTitle = std::string(titleLen + 1, '\0');
-				GetWindowTextA(hwnd, windowTitle.data(), titleLen + 1);
+				GetWindowTextA(application_hwnd, windowTitle.data(), titleLen + 1);
 				windowTitle.resize(titleLen);
 			}
 
@@ -169,10 +177,10 @@ void on_frame()
 
 			std::string applicationName;
 
-			DWORD pid = 0;
-			GetWindowThreadProcessId(hwnd, &pid);
+			DWORD applicationPID = 0;
+			GetWindowThreadProcessId(application_hwnd, &applicationPID);
 
-			HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+			HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, applicationPID);
 			if (!hProc) return TRUE; // Continue, dont add if no process name
 
 			char path[MAX_PATH]{};
@@ -188,10 +196,10 @@ void on_frame()
 			if (!hasTitle || windowTitle.empty() || windowTitle == "")
 				windowTitle = applicationName;
 
-			(*applications)[windowTitle] = applicationName;
+			(*applications)[windowTitle] = window_entry_t{ applicationName, application_hwnd };
 
 			return TRUE;
-		}, reinterpret_cast<LPARAM>(&applications));
+			}, reinterpret_cast<LPARAM>(&applications));
 
 
 		{
@@ -290,6 +298,7 @@ void on_frame()
 					if (!screen.source.get()) {
 						screen.source_application_display_name.clear();
 						screen.source_application_name.clear();
+						screen.source_application_hwnd = nullptr;
 					}
 
 					const char* preview = screen.source_application_name.empty() ? "Select Source..." : screen.source_application_name.c_str();
@@ -298,12 +307,13 @@ void on_frame()
 					if (ImGui::BeginCombo("##appcombo", preview))
 					{
 						int i = 0;
-						for (const auto& [title, application] : applications) {
-							bool selected = (title == screen.source_application_display_name) ? true : ((application == screen.source_application_name) ? true : false);
+						for (const auto& [title, entry] : applications) {
+							bool selected = (entry.application_hwnd == (HWND)screen.source_application_hwnd);
 
-							if (ImGui::Selectable(("[" + application + "] " + title + "##" + std::to_string(i)).c_str(), selected)) {
-								screen.source_application_name = application;
+							if (ImGui::Selectable(("[" + entry.applicationName + "] " + title + "##" + std::to_string(i)).c_str(), selected)) {
+								screen.source_application_name = entry.applicationName;
 								screen.source_application_display_name = title;
+								screen.source_application_hwnd = (void*)entry.application_hwnd;
 								changed = true;
 							}
 
@@ -320,15 +330,16 @@ void on_frame()
 						screen.source.reset(); // Destroy before construct
 
 						if (screen.legacyCapture) {
-							screen.source = sources::CreateWindowSource(screen.source_application_name.c_str(), screen.source_application_display_name.c_str());
+							screen.source = sources::CreateWindowSource((HWND)screen.source_application_hwnd, screen.source_application_display_name.c_str());
 						}
 						else {
-							screen.source = sources::CreateWgcWindowSource(screen.source_application_name.c_str(), screen.source_application_display_name.c_str());
+							screen.source = sources::CreateWgcWindowSource((HWND)screen.source_application_hwnd, screen.source_application_display_name.c_str());
 						}
 
 						if (!screen.source.get()) {
 							screen.source_application_display_name.clear();
 							screen.source_application_name.clear();
+							screen.source_application_hwnd = nullptr;
 							ImGui::OpenPopup("Source Error");
 						}
 

--- a/PrismTextureStreamerFB/screens.h
+++ b/PrismTextureStreamerFB/screens.h
@@ -24,6 +24,7 @@ struct screen_t
 	uint32_t override_texture_size_w{}; // 64
 	uint32_t override_texture_size_h{}; // 2048
 
+	void* source_application_hwnd{};
 	std::string source_application_name;
 	std::string source_application_display_name;
 	std::unique_ptr<IContentSource> source;

--- a/PrismTextureStreamerFB/sources/wgc_window.cpp
+++ b/PrismTextureStreamerFB/sources/wgc_window.cpp
@@ -21,81 +21,13 @@ using namespace winrt::Windows;
 
 #pragma comment(lib, "dxgi.lib")
 
-struct FindWindowData {
-    const char* exeName;
-    const char* windowTitle;
-    HWND result;
-};
-static HWND FindWindowByNameAndTitle(const char* exeName, const char* windowTitle)
-{
-    FindWindowData data{ exeName, windowTitle, nullptr };
-
-    EnumWindows([](HWND hwnd, LPARAM lParam) -> BOOL {
-        auto* data = reinterpret_cast<FindWindowData*>(lParam);
-
-        if (!IsWindowVisible(hwnd))
-            return TRUE;
-
-        LONG exStyle = GetWindowLongA(hwnd, GWL_EXSTYLE);
-        if (exStyle & WS_EX_TOOLWINDOW)
-            return TRUE;
-
-        bool titleMatch{};
-        if (data->windowTitle) {
-            LRESULT lengthResult = 0;
-            if (!SendMessageTimeoutA(hwnd, WM_GETTEXTLENGTH, 0, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK, 200, (PDWORD_PTR)&lengthResult)) {
-                return TRUE; // didn't respond in time - skip it
-            }
-            int titleLen = static_cast<int>(lengthResult);
-
-            if (titleLen != 0)
-            {
-                std::string windowTitle = std::string(titleLen + 1, '\0');
-                GetWindowTextA(hwnd, windowTitle.data(), titleLen + 1);
-                windowTitle.resize(titleLen);
-
-                if (windowTitle == std::string_view(data->windowTitle))
-                    titleMatch = true; // Title matches, but so must the exe name
-            }
-            else
-                return TRUE; // Window title was given as a search filter, so if no title, skip
-        }
-
-        DWORD pid = 0;
-        GetWindowThreadProcessId(hwnd, &pid);
-
-        HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
-        if (!hProc) return TRUE;
-
-        char path[MAX_PATH]{};
-        DWORD size = MAX_PATH;
-        QueryFullProcessImageNameA(hProc, 0, path, &size);
-        CloseHandle(hProc);
-
-        std::string_view applicationName(path);
-        auto pos = applicationName.rfind('\\');
-        applicationName = pos != std::string::npos ? applicationName.substr(pos + 1) : applicationName;
-
-        bool exeMatch = applicationName == std::string_view(data->exeName);
-
-        if (exeMatch && (!data->windowTitle || titleMatch)) {
-            data->result = hwnd;
-            return FALSE; // Exe matches, and there is either no title, or the title matched
-        }
-
-        return TRUE;
-    }, reinterpret_cast<LPARAM>(&data));
-
-    return data.result;
-}
-
-static Graphics::Capture::GraphicsCaptureItem CreateCaptureItemForWindow(HWND hwnd)
+static Graphics::Capture::GraphicsCaptureItem CreateCaptureItemForWindow(HWND application_hwnd)
 {
     auto interopFactory = winrt::get_activation_factory<Graphics::Capture::GraphicsCaptureItem, IGraphicsCaptureItemInterop>();
 
     Graphics::Capture::GraphicsCaptureItem item{ nullptr };
     winrt::check_hresult(interopFactory->CreateForWindow(
-        hwnd,
+        application_hwnd,
         winrt::guid_of<ABI::Windows::Graphics::Capture::IGraphicsCaptureItem>(),
         winrt::put_abi(item))
     );
@@ -112,9 +44,9 @@ static Graphics::DirectX::Direct3D11::IDirect3DDevice CreateD3DDeviceForWgc(ID3D
     return inspectable.as<Graphics::DirectX::Direct3D11::IDirect3DDevice>();
 }
 
-winrt::com_ptr<IDXGIAdapter> GetAdapterForWindow(HWND hwnd)
+winrt::com_ptr<IDXGIAdapter> GetAdapterForWindow(HWND application_hwnd)
 {
-    HMONITOR monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
+    HMONITOR monitor = MonitorFromWindow(application_hwnd, MONITOR_DEFAULTTONEAREST);
 
     winrt::com_ptr<IDXGIFactory1> factory;
     winrt::check_hresult(CreateDXGIFactory1(IID_PPV_ARGS(factory.put())));
@@ -135,7 +67,7 @@ winrt::com_ptr<IDXGIAdapter> GetAdapterForWindow(HWND hwnd)
     return nullptr; // caller falls back to default adapter
 }
 
-winrt::com_ptr<ID3D11Device> CreateWgcCaptureDevice(HWND hwnd)
+winrt::com_ptr<ID3D11Device> CreateWgcCaptureDevice(HWND application_hwnd)
 {
     winrt::com_ptr<ID3D11Device> device;
     winrt::com_ptr<ID3D11DeviceContext> context;
@@ -146,7 +78,7 @@ winrt::com_ptr<ID3D11Device> CreateWgcCaptureDevice(HWND hwnd)
     flags |= D3D11_CREATE_DEVICE_DEBUG;
 #endif
 
-    auto adapter = GetAdapterForWindow(hwnd);
+    auto adapter = GetAdapterForWindow(application_hwnd);
     D3D_DRIVER_TYPE driverType = adapter ? D3D_DRIVER_TYPE_UNKNOWN : D3D_DRIVER_TYPE_HARDWARE;
 
     HRESULT hr = D3D11CreateDevice(
@@ -168,9 +100,8 @@ namespace sources {
     class WgcWindowSource : public IContentSource
     {
     private:
-        char* m_appname{};
+        HWND m_apphwnd{};
         char* m_apptitle{};
-        HWND m_hwnd{};
         std::atomic<uint32_t> m_width{};
         std::atomic<uint32_t> m_height{};
 
@@ -264,11 +195,9 @@ namespace sources {
         }
 
     public:
-        explicit WgcWindowSource(const char* application_name, const char* application_title)
+        explicit WgcWindowSource(HWND application_hwnd, const char* application_title)
         {
-            // Create our own ownership
-            m_appname = new char[strlen(application_name) + 1] {};
-            strcpy(m_appname, application_name);
+            m_apphwnd = application_hwnd;
 
             // title is optional
             if (application_title) {
@@ -288,24 +217,22 @@ namespace sources {
                 m_frameArrivedRevoker.revoke();
                 if (m_session) m_session.Close();
                 if (m_framePool) m_framePool.Close();
-            });
+                });
 
 
-            scs_log(0, "[WgcWindowSource] Source for %s (%s) has stopped", m_appname, m_apptitle ? m_apptitle : "NO_TITLE");
-            if (m_appname) delete[] m_appname;
+            scs_log(0, "[WgcWindowSource] Source for (%s) has stopped", m_apptitle ? m_apptitle : "NO_TITLE");
             if (m_apptitle) delete[] m_apptitle;
         }
 
         bool Start()
         {
             try {
-                m_hwnd = FindWindowByNameAndTitle(m_appname, m_apptitle);
-                if (!m_hwnd) { scs_log(2, "[WgcWindowSource] Application %s (%s) not found at source startup", m_appname, m_apptitle ? m_apptitle : "NO_TITLE"); return false; }
+                if (!IsWindow(m_apphwnd)) { scs_log(2, "[WgcWindowSource] Application %s (%s) not found at source startup", m_apptitle ? m_apptitle : "NO_TITLE"); return false; }
 
-                m_d3dDevice = CreateWgcCaptureDevice(m_hwnd);
+                m_d3dDevice = CreateWgcCaptureDevice(m_apphwnd);
 
                 m_wgcDevice = CreateD3DDeviceForWgc(m_d3dDevice.get());
-                m_item = CreateCaptureItemForWindow(m_hwnd);
+                m_item = CreateCaptureItemForWindow(m_apphwnd);
 
                 m_lastSize = m_item.Size();
                 if (m_lastSize.Width == 0 || m_lastSize.Height == 0) {
@@ -326,7 +253,7 @@ namespace sources {
                 m_session.StartCapture();
                 //m_session.IsBorderRequired(false); // Disable the windows orange border from capturing
 
-                scs_log(0, "[WgcWindowSource] Source for %s (%s) has started", m_appname, m_apptitle ? m_apptitle : "NO_TITLE");
+                scs_log(0, "[WgcWindowSource] Source for %s (%s) has started", m_apptitle ? m_apptitle : "NO_TITLE");
 
                 return true;
             }
@@ -355,15 +282,14 @@ namespace sources {
     };
 
 
-    std::unique_ptr<IContentSource> CreateWgcWindowSource(const char* application_name, const char* window_title)
+    std::unique_ptr<IContentSource> CreateWgcWindowSource(HWND application_hwnd, const char* application_title)
     {
-        std::string appname(application_name);
-        std::string apptitle = window_title ? window_title : std::string();
+        std::string apptitle = application_title ? application_title : std::string();
 
-        return WgcDispatcher::Instance().PostResult([appname, apptitle]() -> std::unique_ptr<IContentSource> {
-            auto src = std::make_unique<WgcWindowSource>(appname.c_str(), apptitle.empty() ? nullptr : apptitle.c_str());
+        return WgcDispatcher::Instance().PostResult([application_hwnd, apptitle]() -> std::unique_ptr<IContentSource> {
+            auto src = std::make_unique<WgcWindowSource>(application_hwnd, apptitle.empty() ? nullptr : apptitle.c_str());
             if (!src->Start()) return nullptr;
             return src;
-        });
+            });
     }
 }

--- a/PrismTextureStreamerFB/sources/wgc_window.cpp
+++ b/PrismTextureStreamerFB/sources/wgc_window.cpp
@@ -220,7 +220,7 @@ namespace sources {
                 });
 
 
-            scs_log(0, "[WgcWindowSource] Source for has %s stopped", m_apptitle ? m_apptitle : "NO_TITLE");
+            scs_log(0, "[WgcWindowSource] Source for %s has stopped", m_apptitle ? m_apptitle : "NO_TITLE");
             if (m_apptitle) delete[] m_apptitle;
         }
 

--- a/PrismTextureStreamerFB/sources/wgc_window.cpp
+++ b/PrismTextureStreamerFB/sources/wgc_window.cpp
@@ -220,7 +220,7 @@ namespace sources {
                 });
 
 
-            scs_log(0, "[WgcWindowSource] Source for has stopped", m_apptitle ? m_apptitle : "NO_TITLE");
+            scs_log(0, "[WgcWindowSource] Source for has %s stopped", m_apptitle ? m_apptitle : "NO_TITLE");
             if (m_apptitle) delete[] m_apptitle;
         }
 

--- a/PrismTextureStreamerFB/sources/wgc_window.cpp
+++ b/PrismTextureStreamerFB/sources/wgc_window.cpp
@@ -220,14 +220,14 @@ namespace sources {
                 });
 
 
-            scs_log(0, "[WgcWindowSource] Source for (%s) has stopped", m_apptitle ? m_apptitle : "NO_TITLE");
+            scs_log(0, "[WgcWindowSource] Source for has stopped", m_apptitle ? m_apptitle : "NO_TITLE");
             if (m_apptitle) delete[] m_apptitle;
         }
 
         bool Start()
         {
             try {
-                if (!IsWindow(m_apphwnd)) { scs_log(2, "[WgcWindowSource] Application %s (%s) not found at source startup", m_apptitle ? m_apptitle : "NO_TITLE"); return false; }
+                if (!IsWindow(m_apphwnd)) { scs_log(2, "[WgcWindowSource] Application %s not found at source startup", m_apptitle ? m_apptitle : "NO_TITLE"); return false; }
 
                 m_d3dDevice = CreateWgcCaptureDevice(m_apphwnd);
 
@@ -253,7 +253,7 @@ namespace sources {
                 m_session.StartCapture();
                 //m_session.IsBorderRequired(false); // Disable the windows orange border from capturing
 
-                scs_log(0, "[WgcWindowSource] Source for %s (%s) has started", m_apptitle ? m_apptitle : "NO_TITLE");
+                scs_log(0, "[WgcWindowSource] Source for %s has started", m_apptitle ? m_apptitle : "NO_TITLE");
 
                 return true;
             }

--- a/PrismTextureStreamerFB/sources/wgc_window.h
+++ b/PrismTextureStreamerFB/sources/wgc_window.h
@@ -4,5 +4,5 @@
 #include <memory>
 
 namespace sources {
-	std::unique_ptr<IContentSource> CreateWgcWindowSource(const char* application_name, const char* window_title = nullptr);
+	std::unique_ptr<IContentSource> CreateWgcWindowSource(HWND application_hwnd, const char* application_title = nullptr);
 }

--- a/PrismTextureStreamerFB/sources/window.cpp
+++ b/PrismTextureStreamerFB/sources/window.cpp
@@ -8,82 +8,12 @@ using namespace scs_logging;
 #include <vector>
 #include <mutex>
 
-struct FindWindowData {
-    const char* exeName;
-    const char* windowTitle;
-    HWND result;
-};
-static HWND FindWindowByNameAndTitle(const char* exeName, const char* windowTitle)
-{
-    FindWindowData data{ exeName, windowTitle, nullptr };
-
-    EnumWindows([](HWND hwnd, LPARAM lParam) -> BOOL {
-        auto* data = reinterpret_cast<FindWindowData*>(lParam);
-
-        if (!IsWindowVisible(hwnd))
-            return TRUE;
-
-        LONG exStyle = GetWindowLongA(hwnd, GWL_EXSTYLE);
-        if (exStyle & WS_EX_TOOLWINDOW)
-            return TRUE;
-
-        bool titleMatch{};
-        if (data->windowTitle) {
-            LRESULT lengthResult = 0;
-            if (!SendMessageTimeoutA(hwnd, WM_GETTEXTLENGTH, 0, 0, SMTO_ABORTIFHUNG | SMTO_BLOCK, 200, (PDWORD_PTR)&lengthResult)) {
-                return TRUE; // didn't respond in time - skip it
-            }
-            int titleLen = static_cast<int>(lengthResult);
-
-            if (titleLen != 0)
-            {
-                std::string windowTitle = std::string(titleLen + 1, '\0');
-                GetWindowTextA(hwnd, windowTitle.data(), titleLen + 1);
-                windowTitle.resize(titleLen);
-
-                if (windowTitle == std::string_view(data->windowTitle))
-                    titleMatch = true; // Title matches, but so must the exe name
-            }
-            else
-                return TRUE; // Window title was given as a search filter, so if no title, skip
-        }
-
-        DWORD pid = 0;
-        GetWindowThreadProcessId(hwnd, &pid);
-
-        HANDLE hProc = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
-        if (!hProc) return TRUE;
-
-        char path[MAX_PATH]{};
-        DWORD size = MAX_PATH;
-        QueryFullProcessImageNameA(hProc, 0, path, &size);
-        CloseHandle(hProc);
-
-        std::string_view applicationName(path);
-        auto pos = applicationName.rfind('\\');
-        applicationName = pos != std::string::npos ? applicationName.substr(pos + 1) : applicationName;
-
-        bool exeMatch = applicationName == std::string_view(data->exeName);
-
-        if (exeMatch && (!data->windowTitle || titleMatch)) {
-            data->result = hwnd;
-            return FALSE; // Exe matches, and there is either no title, or the title matched
-        }
-
-        return TRUE;
-        }, reinterpret_cast<LPARAM>(&data));
-
-    return data.result;
-}
-
-
 namespace sources {
     class WindowSource : public IContentSource
     {
     private:
-        char* m_appname{};
+        HWND m_apphwnd{};
         char* m_apptitle{};
-        HWND m_hwnd{};
         std::atomic<uint32_t> m_width{};
         std::atomic<uint32_t> m_height{};
         uint8_t m_framerate{};
@@ -98,7 +28,7 @@ namespace sources {
 
         void CaptureLoop()
         {
-            HDC windowDC = GetDC(m_hwnd);
+            HDC windowDC = GetDC(m_apphwnd);
             HDC memDC = CreateCompatibleDC(windowDC);
             HBITMAP bitmap = CreateCompatibleBitmap(windowDC, m_width, m_height);
             HGDIOBJ oldObj = SelectObject(memDC, bitmap);
@@ -121,11 +51,11 @@ namespace sources {
                 const auto frameInterval = std::chrono::milliseconds(1000 / m_framerate);
                 auto frameStart = std::chrono::steady_clock::now();
 
-                if (!IsWindow(m_hwnd)) { scs_log(0, "[WindowSource] Target window %s (%s) no longer exists, stopping capture for this window", m_appname, m_apptitle ? m_apptitle : "NO_TITLE"); break; }
-                if (IsIconic(m_hwnd)) { std::this_thread::sleep_for(frameInterval); continue; } // minimized
+                if (!IsWindow(m_apphwnd)) { scs_log(0, "[WindowSource] Target window %s (%s) no longer exists, stopping capture for this window", m_apptitle ? m_apptitle : "NO_TITLE"); break; }
+                if (IsIconic(m_apphwnd)) { std::this_thread::sleep_for(frameInterval); continue; } // minimized
 
                 RECT rect;
-                GetClientRect(m_hwnd, &rect);
+                GetClientRect(m_apphwnd, &rect);
                 const uint32_t width = rect.right - rect.left;
                 const uint32_t height = rect.bottom - rect.top;
 
@@ -142,10 +72,10 @@ namespace sources {
                     SelectObject(memDC, bitmap);
                 }
 
-                BOOL pwOk = PrintWindow(m_hwnd, memDC, 2 /* PW_RENDERFULLCONTENT */);
+                BOOL pwOk = PrintWindow(m_apphwnd, memDC, 2 /* PW_RENDERFULLCONTENT */);
                 if (!pwOk)
                 {
-                    scs_log(0, "[WindowSource] PrintWindow failed for %s (%s), err=%lu", m_appname, m_apptitle ? m_apptitle : "NO_TITLE", GetLastError());
+                    scs_log(0, "[WindowSource] PrintWindow failed for %s (%s), err=%lu", m_apptitle ? m_apptitle : "NO_TITLE", GetLastError());
                     std::this_thread::sleep_for(frameInterval);
                     continue;
                 }
@@ -180,17 +110,15 @@ namespace sources {
             SelectObject(memDC, oldObj);
             DeleteObject(bitmap);
             DeleteDC(memDC);
-            ReleaseDC(m_hwnd, windowDC);
+            ReleaseDC(m_apphwnd, windowDC);
 
-            scs_log(0, "[WindowSource] Source for %s (%s) has stopped", m_appname, m_apptitle ? m_apptitle : "NO_TITLE");
+            scs_log(0, "[WindowSource] Source for %s (%s) has stopped", m_apptitle ? m_apptitle : "NO_TITLE");
         }
 
     public:
-        explicit WindowSource(const char* application_name, const char* application_title)
+        explicit WindowSource(HWND application_hwnd, const char* application_title)
         {
-            // Create our own ownership
-            m_appname = new char[strlen(application_name) + 1]{};
-            strcpy(m_appname, application_name);
+            m_apphwnd = application_hwnd;
 
             if (application_title) {
                 m_apptitle = new char[strlen(application_title) + 1] {};
@@ -202,7 +130,6 @@ namespace sources {
             m_stopRequested = true;
             if (m_thread.joinable()) m_thread.join();
 
-            if (m_appname) delete[] m_appname;
             if (m_apptitle) delete[] m_apptitle;
         }
 
@@ -210,12 +137,11 @@ namespace sources {
         bool Start(uint8_t framerate)
         {
             m_framerate = framerate;
-            m_hwnd = FindWindowByNameAndTitle(m_appname, m_apptitle);
-            if (!m_hwnd) { scs_log(2, "[WindowSource] Application %s (%s) not found at source startup", m_appname, m_apptitle ? m_apptitle : "NO_TITLE"); return false; }
+            if (!IsWindow(m_apphwnd)) { scs_log(2, "[WindowSource] Application %s (%s) not found at source startup", m_apptitle ? m_apptitle : "NO_TITLE"); return false; }
 
             m_thread = std::thread(&WindowSource::CaptureLoop, this);
 
-            scs_log(0, "[WindowSource] Source for %s (%s) has started", m_appname, m_apptitle ? m_apptitle : "NO_TITLE");
+            scs_log(0, "[WindowSource] Source for %s (%s) has started", m_apptitle ? m_apptitle : "NO_TITLE");
             return true;
         }
 
@@ -237,9 +163,9 @@ namespace sources {
     };
 
 
-	std::unique_ptr<IContentSource> CreateWindowSource(const char* application_name, const char* application_title, uint8_t framerate)
+	std::unique_ptr<IContentSource> CreateWindowSource(HWND application_hwnd, const char* application_title, uint8_t framerate)
 	{
-		auto src = std::make_unique<WindowSource>(application_name, application_title);
+		auto src = std::make_unique<WindowSource>(application_hwnd, application_title);
 		if (!src->Start(framerate)) return nullptr;
 		return src;
 	}

--- a/PrismTextureStreamerFB/sources/window.cpp
+++ b/PrismTextureStreamerFB/sources/window.cpp
@@ -51,7 +51,7 @@ namespace sources {
                 const auto frameInterval = std::chrono::milliseconds(1000 / m_framerate);
                 auto frameStart = std::chrono::steady_clock::now();
 
-                if (!IsWindow(m_apphwnd)) { scs_log(0, "[WindowSource] Target window %s (%s) no longer exists, stopping capture for this window", m_apptitle ? m_apptitle : "NO_TITLE"); break; }
+                if (!IsWindow(m_apphwnd)) { scs_log(0, "[WindowSource] Target window %s no longer exists, stopping capture for this window", m_apptitle ? m_apptitle : "NO_TITLE"); break; }
                 if (IsIconic(m_apphwnd)) { std::this_thread::sleep_for(frameInterval); continue; } // minimized
 
                 RECT rect;
@@ -75,7 +75,7 @@ namespace sources {
                 BOOL pwOk = PrintWindow(m_apphwnd, memDC, 2 /* PW_RENDERFULLCONTENT */);
                 if (!pwOk)
                 {
-                    scs_log(0, "[WindowSource] PrintWindow failed for %s (%s), err=%lu", m_apptitle ? m_apptitle : "NO_TITLE", GetLastError());
+                    scs_log(0, "[WindowSource] PrintWindow failed for %s, err=%lu", m_apptitle ? m_apptitle : "NO_TITLE", GetLastError());
                     std::this_thread::sleep_for(frameInterval);
                     continue;
                 }
@@ -112,7 +112,7 @@ namespace sources {
             DeleteDC(memDC);
             ReleaseDC(m_apphwnd, windowDC);
 
-            scs_log(0, "[WindowSource] Source for %s (%s) has stopped", m_apptitle ? m_apptitle : "NO_TITLE");
+            scs_log(0, "[WindowSource] Source for %s has stopped", m_apptitle ? m_apptitle : "NO_TITLE");
         }
 
     public:
@@ -137,11 +137,11 @@ namespace sources {
         bool Start(uint8_t framerate)
         {
             m_framerate = framerate;
-            if (!IsWindow(m_apphwnd)) { scs_log(2, "[WindowSource] Application %s (%s) not found at source startup", m_apptitle ? m_apptitle : "NO_TITLE"); return false; }
+            if (!IsWindow(m_apphwnd)) { scs_log(2, "[WindowSource] Application %s not found at source startup", m_apptitle ? m_apptitle : "NO_TITLE"); return false; }
 
             m_thread = std::thread(&WindowSource::CaptureLoop, this);
 
-            scs_log(0, "[WindowSource] Source for %s (%s) has started", m_apptitle ? m_apptitle : "NO_TITLE");
+            scs_log(0, "[WindowSource] Source for %s has started", m_apptitle ? m_apptitle : "NO_TITLE");
             return true;
         }
 

--- a/PrismTextureStreamerFB/sources/window.h
+++ b/PrismTextureStreamerFB/sources/window.h
@@ -4,5 +4,5 @@
 #include <memory>
 
 namespace sources {
-	std::unique_ptr<IContentSource> CreateWindowSource(const char* application_name, const char* application_title = nullptr, uint8_t framerate = 30);
+	std::unique_ptr<IContentSource> CreateWindowSource(HWND application_hwnd, const char* application_title = nullptr, uint8_t framerate = 30);
 }


### PR DESCRIPTION
## Summary

1. Replaced application name detection with HWD based detection.
2. Moved menu visibility handling into its own dedicated function.
3. Cleaned up some variable names.

## Why

1. Using HWD provides more reliable window detection and ensures the dropdown menu highlights the correct selection when multiple instances of the same `.exe` are running.
2. Menu visibility is now handled through a dedicated function, allowing it to be called from anywhere in the code. This also enables improvements such as automatically closing the menu when selecting 'Apply Unsaved Changes'.
3. Small change, better readability and matches other variable naming schemes in the code.
